### PR TITLE
remove deprecated library/function calls

### DIFF
--- a/inst/doc/vigsrc/RforProteomics.Rnw
+++ b/inst/doc/vigsrc/RforProteomics.Rnw
@@ -527,7 +527,6 @@ homepage\footnote{\url{http://strimmerlab.org/software/maldiquant/}}.
 <<mqload, tidy=FALSE>>=
 ## load packages
 library("MALDIquant")
-library("readBrukerFlexData")
 library("MALDIquantForeign")
 ## getting test data
 datapath <- 
@@ -560,11 +559,7 @@ s2 <- transformIntensity(s, fun=sqrt)
 s2
 
 ## smoothing - 5 point moving average 
-simpleSmooth <- function(y) {
-  return ( filter(y, rep(1, 5)/5, sides=2) ) 
-}
-
-s3 <- transformIntensity(s2, simpleSmooth)
+s3 <- transformIntensity(s2, movingAverage, halfWindowSize=2)
 s3
 length(s2) # 22431
 length(s3) # 22427 - at both ends data points have been removed


### PR DESCRIPTION
Dear Laurent,

thanks for your great `RforProteomics` package.
I have two small fixes for the `MALDIquant` example:
1. `readBrukerFlexData` is imported by `MALDIquantForeign`, there is no need to call `library("readBrukerFlexData")`.
2. `MALDIquant` provides its own `movingAverage` function now (since version 1.5), there is no need to define your own `simpleSmooth` function anymore.

Best wishes,

Sebastian
