### PR TITLE
importBrukerFlex: set verbose=FALSE

### DIFF
--- a/inst/doc/vigsrc/RforProteomics.Rnw
+++ b/inst/doc/vigsrc/RforProteomics.Rnw
@@ -534,7 +534,7 @@ datapath <-
                         package = "readBrukerFlexData"), 
             "2010_05_19_Gibb_C8_A1")
 dir(datapath)
-sA1 <- importBrukerFlex(datapath)
+sA1 <- importBrukerFlex(datapath, verbose=FALSE)
 # in the following we use only the first spectrum
 s <- sA1[[1]] 
 


### PR DESCRIPTION
`MALDIquantForeign 0.4` produces verbose output now. To avoid long ugly lines overlapping the borders use `verbose=FALSE`.

default output of `importBrukerFlex`:
![snapshot1](https://f.cloud.github.com/assets/1828443/448384/7becb22a-b242-11e2-84c2-e89fc1e9f33d.png)

`verbose=FALSE`:
![snapshot2](https://f.cloud.github.com/assets/1828443/448400/1ff0cc6c-b243-11e2-82eb-8262fa9afe15.png)
