### PR TITLE
adapt to upcoming MALDIquant 1.12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Depends: MSnbase
 Imports: R.utils, Biobase, rpx, biocViews, BiocInstaller,
         interactiveDisplay, shiny
 Suggests: knitr, rmarkdown, BiocStyle, mzR, xcms, msdata, isobar,
-        MALDIquant (>= 1.11), MALDIquantForeign, readBrukerFlexData,
+        MALDIquant (>= 1.12), MALDIquantForeign, readBrukerFlexData,
         rTANDEM, synapter, synapterdata, IPPD, Rdisop, OrgMassSpecR,
         BRAIN, rols, hpar, GO.db, org.Hs.eg.db, biomaRt, RColorBrewer,
         ggplot2, reshape2, xtable, lattice, mzID, pRoloc, pRolocdata,

--- a/vignettes/vigsrc/RProtVis.Rmd
+++ b/vignettes/vigsrc/RProtVis.Rmd
@@ -809,7 +809,7 @@ and
 [`mapping`](http://bioconductor.org/packages/devel/bioc/vignettes/Pbase/inst/doc/mapping.html) vignettes.
 
 
-### Imaging mass spectrometry
+### Mass spectrometry imaging
 
 The following code chunk downloads a MALDI imaging dataset from a
 mouse kidney shared by
@@ -820,7 +820,7 @@ interesting *M/Z* regions.
 <!-- Not running this code chunk as the access to the data (75M) -->
 <!-- on figshare seems to hang or become very slow at times -->
 
-```{r mqims, cache=FALSE, eval=FALSE, warning=FALSE}
+```{r mqmsi, cache=FALSE, eval=FALSE, warning=FALSE}
 library("MALDIquant")
 library("MALDIquantForeign")
 
@@ -842,15 +842,12 @@ lines(avgPeaks, col = "red")
 labelPeaks(avgPeaks, cex = 1)
 
 par(mar = c(0.5, 0.5, 1.5, 0.5))
-for (i in seq(along = avgPeaks)) {
-  range <- mass(avgPeaks)[i] + c(-1, 1)
-  plotImsSlice(spectra, range = range,
-               main = paste(round(range, 2), collapse = " - "))
-}
+plotMsiSlice(spectra, center = mass(avgPeaks), tolerance = 1,
+             plotInteractive = TRUE)
 par(oldPar)
 ```
 
-![ims-shiny screeshot](./figures/mqims-1.png)
+![mqmsi](./figures/mqmsi-1.png)
 
 ### An interactive `r CRANpkg("shiny")` app for Imaging mass spectrometry
 


### PR DESCRIPTION


Dear Laurent,

the upcoming MALDIquant release will have some changes to the Mass Spectrometry Imaging functionality. `plotImsSlice` is now deprecated and replaced by a complete rewritten and faster function `plotMsiSlice` (please note the difference *IMS* vs *MSI*; I decided to rename the new function because *IMS* often refers to *ionmobility mass spectrometry*).

This PR is a reminder. I will merge it myself when MALDIquant 1.12 is released on CRAN.
It would be necessary to cherry-pick this PR into the stable/release branch on bioc as well.
Also I don't really know how the vignettes are built (it seems that the Makefile could only build the `RforProteomics` vignette and not the `RProtViz` vignette). That's why this PR just replace the code in the `.Rmd` file. Could you explain how you generate the .html document or create the images (png + pdf) and .html file yourself?

Best wishes,

Sebastian
